### PR TITLE
feat: send contact form using external service

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -127,30 +127,6 @@
     </footer>
 
     <script src="../js/main.js"></script>
-    <script>
-        // Contact form handling
-        document.querySelector('.contact-form').addEventListener('submit', function(e) {
-            e.preventDefault();
-            
-            // Get form data
-            const formData = new FormData(this);
-            const data = Object.fromEntries(formData);
-            
-            // Create mailto link
-            const subject = `Nuevo mensaje de ${data.nombre} - ${data.proyecto || 'Proyecto general'}`;
-            const body = `
-Nombre: ${data.nombre}
-Email: ${data.email}
-Empresa: ${data.empresa || 'No especificada'}
-Tipo de Proyecto: ${data.proyecto || 'No especificado'}
-
-Mensaje:
-${data.mensaje}
-            `;
-            
-            const mailtoLink = `mailto:heligonzalespe@gmail.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-            window.location.href = mailtoLink;
-        });
-    </script>
+    <script src="../js/contact.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- send contact form data to configurable endpoint via fetch
- show success and error messages after submission
- load contact form script from contact page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb17162248332ba8cf46c002d9982