### PR TITLE
Replace background-image divs with imgs

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -348,14 +348,8 @@ body {
     background: var(--gray-100);
     border-radius: 12px;
     margin-bottom: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--gray-400);
-    font-size: 1.5rem;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    object-fit: cover;
+    display: block;
 }
 
 .project-title {
@@ -486,14 +480,9 @@ body {
     background: var(--gray-100);
     border-radius: 16px;
     height: 400px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--gray-400);
-    font-size: 1.5rem;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    width: 100%;
+    object-fit: cover;
+    display: block;
 }
 
 .spotlight-info h3 {
@@ -541,16 +530,11 @@ body {
     height: 80px;
     background: var(--white);
     border-radius: 12px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--gray-400);
-    font-weight: 700;
     box-shadow: var(--shadow-sm);
     transition: all 0.2s;
-    background-size: 60px 60px;
-    background-position: center;
-    background-repeat: no-repeat;
+    padding: 10px;
+    object-fit: contain;
+    display: block;
 }
 
 .tech-logo:hover {

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
             <div class="projects-grid">
                 <!-- ML Project -->
                 <div class="project-card" data-category="ml">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/cmab-thumbnail.jpg')">📊</div>
+                    <img class="project-thumbnail" src="assets/images/projects/cmab-thumbnail.jpg" alt="Personalización bancaria con CMAB" loading="lazy">
                     <h3 class="project-title">Personalización bancaria con CMAB</h3>
                     <p class="project-description">Sistema de bandits contextuales para optimizar campañas crediticias en tiempo real.</p>
                     <div class="project-tech">
@@ -127,7 +127,7 @@
 
                 <!-- LLMs Project -->
                 <div class="project-card" data-category="llms">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/llm-assistant-thumbnail.jpg')">🤖</div>
+                    <img class="project-thumbnail" src="assets/images/projects/llm-assistant-thumbnail.jpg" alt="Asistente de atención al cliente con LLMs" loading="lazy">
                     <h3 class="project-title">Asistente de atención al cliente con LLMs</h3>
                     <p class="project-description">Sistema de comprensión semántica para clasificación y respuesta automática de tickets.</p>
                     <div class="project-tech">
@@ -145,7 +145,7 @@
 
                 <!-- Agentes Project -->
                 <div class="project-card" data-category="agentes">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/whatsapp-agent-thumbnail.jpg')">⚡</div>
+                    <img class="project-thumbnail" src="assets/images/projects/whatsapp-agent-thumbnail.jpg" alt="Agente de leads en WhatsApp" loading="lazy">
                     <h3 class="project-title">Agente de leads en WhatsApp</h3>
                     <p class="project-description">Orquestación de agentes para captura y cualificación automática de leads multicanal.</p>
                     <div class="project-tech">
@@ -163,7 +163,7 @@
 
                 <!-- MCP Project -->
                 <div class="project-card" data-category="mcp">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/mcp-coordination-thumbnail.jpg')">🔗</div>
+                    <img class="project-thumbnail" src="assets/images/projects/mcp-coordination-thumbnail.jpg" alt="Coordinación multi-agente con MCP" loading="lazy">
                     <h3 class="project-title">Coordinación multi-agente con MCP</h3>
                     <p class="project-description">Protocolo de comunicación entre agentes para tareas complejas distribuidas.</p>
                     <div class="project-tech">
@@ -181,7 +181,7 @@
 
                 <!-- RAG Project -->
                 <div class="project-card" data-category="rag">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/rag-docs-thumbnail.jpg')">📚</div>
+                    <img class="project-thumbnail" src="assets/images/projects/rag-docs-thumbnail.jpg" alt="RAG para documentación técnica" loading="lazy">
                     <h3 class="project-title">RAG para documentación técnica</h3>
                     <p class="project-description">Sistema de recuperación y generación para consultas sobre documentación interna.</p>
                     <div class="project-tech">
@@ -199,7 +199,7 @@
 
                 <!-- Infra Project -->
                 <div class="project-card" data-category="infra">
-                    <div class="project-thumbnail" style="background-image: url('assets/images/projects/mlops-pipeline-thumbnail.jpg')">🐳</div>
+                    <img class="project-thumbnail" src="assets/images/projects/mlops-pipeline-thumbnail.jpg" alt="MLOps Pipeline con K8s" loading="lazy">
                     <h3 class="project-title">MLOps Pipeline con K8s</h3>
                     <p class="project-description">Infraestructura completa para despliegue y monitoreo de modelos ML en producción.</p>
                     <div class="project-tech">
@@ -267,9 +267,7 @@
         <div class="container">
             <h2 class="section-title">Proyecto destacado</h2>
             <div class="spotlight-content">
-                <div class="spotlight-demo" style="background-image: url('assets/images/projects/whatsapp-agent-thumbnail.jpg')">
-                    🎯 Demo del Agente de Leads
-                </div>
+                <img class="spotlight-demo" src="assets/images/projects/whatsapp-agent-thumbnail.jpg" alt="Demo del agente de leads en WhatsApp" loading="lazy">
                 <div class="spotlight-info">
                     <h3>Agente de leads en WhatsApp</h3>
                     <ul class="spotlight-bullets">
@@ -294,14 +292,14 @@
             <p class="section-subtitle">Stack moderno para ir de prototipo a producción</p>
             
             <div class="tech-logos">
-                <div class="tech-logo" style="background-image: url('assets/images/tech/databricks.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/mlflow.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/azure.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/docker.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/kubernetes.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/langchain.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/vowpalwabbit.svg')"></div>
-                <div class="tech-logo" style="background-image: url('assets/images/tech/huggingface.svg')"></div>
+                <img class="tech-logo" src="assets/images/tech/databricks.svg" alt="Databricks" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/mlflow.svg" alt="MLflow" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/azure.svg" alt="Azure" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/docker.svg" alt="Docker" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/kubernetes.svg" alt="Kubernetes" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/langchain.svg" alt="LangChain" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/vowpalwabbit.svg" alt="Vowpal Wabbit" loading="lazy">
+                <img class="tech-logo" src="assets/images/tech/huggingface.svg" alt="Hugging Face" loading="lazy">
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- swap background-image divs for `<img>` tags with descriptive alt text on project cards, spotlight demo and tech logos
- tweak `.project-thumbnail`, `.spotlight-demo` and `.tech-logo` styles for the new image elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb170ef008332a008898fd4bc9548